### PR TITLE
Add j5 changes to 8.0.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "8.0.0",
+  "version": "8.0.0-j5int.1",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="8.0.0">
+    version="8.0.0-j5int.1">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1225,11 +1225,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @return Uri
      */
     private Uri whichContentStore() {
-        if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-            return MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-        } else {
-            return MediaStore.Images.Media.INTERNAL_CONTENT_URI;
-        }
+        return MediaStore.Images.Media.INTERNAL_CONTENT_URI;
     }
 
     /**

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera-tests",
-  "version": "8.0.0",
+  "version": "8.0.0-j5int.1",
   "description": "",
   "cordova": {
     "id": "cordova-plugin-camera-tests",

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera-tests"
-    version="8.0.0">
+    version="8.0.0-j5int.1">
     <name>Cordova Camera Plugin Tests</name>
     <license>Apache 2.0</license>
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Fix Android permission issue around internal storage and emulated SDCards which could crash the app.

This is a re-implementation of https://github.com/j5int/cordova-plugin-camera/pull/1. See that PR for context

### Platforms affected
Android

### Testing
This was tested with https://github.com/j5int/cordova-plugin-media-capture/pull/9 and https://github.com/j5int/cordova-plugin-file/pull/12.

Tested that photo and video attachments can still be added to an operation logbook IndustraForm. Also confirmed that j5 Mobile no longer has Photo and Video permissions in the Android settings.
